### PR TITLE
doc pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7060,6 +7060,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "sunshine-doc"
+version = "0.0.1"
+dependencies = [
+ "clear_on_drop",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "rand 0.7.3",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sunshine-bounty-utils",
+]
+
+[[package]]
 name = "sunshine-donate"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "pallets/bounty",
     "pallets/bounty2",
     "pallets/court",
+    "pallets/doc",
     "pallets/donate",
     "pallets/drip",
     "pallets/grant",

--- a/pallets/doc/Cargo.toml
+++ b/pallets/doc/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "sunshine-doc"
+version = "0.0.1"
+authors = ["Amar Singh <asinghchrony@protonmail.com>"]
+edition = "2018"
+
+license = "GPL-3.0"
+repository = "https://github.com/sunshine-protocol/sunshine-bounty"
+description = "doc commitment registration"
+keywords = ["sunshine", "substrate", "blockchain"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
+sp-std = { version = "2.0.0-rc5", default-features = false }
+sp-runtime = { version = "2.0.0-rc5", default-features = false }
+frame-support = { version = "2.0.0-rc5", default-features = false }
+frame-system = { version = "2.0.0-rc5", default-features = false }
+util = { package = "sunshine-bounty-utils", path = "../../utils", default-features=false}
+clear_on_drop = { version = "0.2.4", features = ["no_cc"] }	# https://github.com/paritytech/substrate/issues/4179
+
+[dev-dependencies]
+rand = "0.7.3"
+sp-io = { version = "2.0.0-rc5", default-features = false }
+sp-core = { version = "2.0.0-rc5", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"sp-std/std",
+	"sp-runtime/std",
+	"frame-support/std",
+	"frame-system/std",
+]

--- a/pallets/doc/src/lib.rs
+++ b/pallets/doc/src/lib.rs
@@ -1,0 +1,180 @@
+#![allow(clippy::string_lit_as_bytes)]
+#![allow(clippy::redundant_closure_call)]
+#![allow(clippy::type_complexity)]
+#![cfg_attr(not(feature = "std"), no_std)]
+//! To store and track CIDs. This module is NOT intended to be used directly.
+
+#[cfg(test)]
+mod tests;
+
+use codec::Codec;
+use frame_support::{
+    decl_error,
+    decl_event,
+    decl_module,
+    decl_storage,
+    ensure,
+    storage::IterableStorageDoubleMap,
+    Parameter,
+};
+use frame_system::ensure_signed;
+use sp_runtime::{
+    traits::{
+        AtLeast32Bit,
+        MaybeSerializeDeserialize,
+        Member,
+        Zero,
+    },
+    DispatchResult,
+};
+use sp_std::{
+    fmt::Debug,
+    prelude::*,
+};
+use util::doc::FullDoc;
+
+type EncodedObj = Vec<u8>;
+
+pub trait Trait: frame_system::Trait {
+    /// The overarching event type
+    type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
+
+    /// Encoded object identifier
+    type CodeId: Parameter
+        + Member
+        + AtLeast32Bit
+        + Codec
+        + Default
+        + Copy
+        + MaybeSerializeDeserialize
+        + Debug
+        + PartialOrd
+        + PartialEq
+        + Zero;
+
+    /// Document identifier
+    type DocId: Parameter
+        + Member
+        + AtLeast32Bit
+        + Codec
+        + Default
+        + Copy
+        + MaybeSerializeDeserialize
+        + Debug
+        + PartialOrd
+        + PartialEq
+        + Zero;
+
+    /// Content identifier, static ipfs reference type
+    type Cid: Parameter + Member + Default;
+}
+
+decl_event!(
+    pub enum Event<T>
+    where
+        <T as Trait>::CodeId,
+        <T as Trait>::DocId,
+        <T as Trait>::Cid,
+    {
+        NewCodeSet(CodeId),
+        NewEncodedObject(CodeId), // TODO: emit EncodedObj after bounded length constraint added
+        NewDoc(DocId, Cid),
+    }
+);
+
+decl_error! {
+    pub enum Error for Module<T: Trait> {
+        CodeIdNotRegistered,
+        CodeAlreadyRegisteredInSet,
+        MustIncludeCodeToCreateNewCodeSet,
+    }
+}
+
+decl_storage! {
+    trait Store for Module<T: Trait> as Doc {
+        /// The nonce for unique code id generation
+        CodeIdCounter get(fn code_id_counter): T::CodeId;
+        /// The nonce for unique doc id generation
+        DocIdCounter get(fn doc_id_counter):T::DocId;
+
+        /// Set of scale-encoded sets
+        pub CodeSets get(fn code_sets): double_map
+            hasher(blake2_128_concat) T::CodeId,
+            hasher(blake2_128_concat) EncodedObj => Option<FullDoc<T::CodeId, EncodedObj>>;
+
+        /// Set of cids
+        pub Docs get(fn docs): map
+            hasher(blake2_128_concat) T::DocId => Option<FullDoc<T::DocId, T::Cid>>;
+    }
+}
+
+decl_module! {
+    pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+        type Error = Error<T>;
+        fn deposit_event() = default;
+
+        #[weight = 0]
+        fn new_code_set(
+            origin,
+            initial_codes: Vec<EncodedObj>, // TODO: bound length
+        ) -> DispatchResult {
+            let _ = ensure_signed(origin)?;
+            ensure!(!initial_codes.is_empty(), Error::<T>::MustIncludeCodeToCreateNewCodeSet);
+            let id = Self::generate_code_uid();
+            initial_codes.into_iter().for_each(|code| {
+                <CodeSets<T>>::insert(id, code.clone(), FullDoc { id, doc: code});
+            });
+            Self::deposit_event(RawEvent::NewCodeSet(id));
+            Ok(())
+        }
+        #[weight = 0]
+        fn new_encoded_object(
+            origin,
+            id: T::CodeId,
+            code: EncodedObj,
+        ) -> DispatchResult {
+            let _ = ensure_signed(origin)?;
+            ensure!(!Self::code_id_dne(id), Error::<T>::CodeIdNotRegistered);
+            ensure!(<CodeSets<T>>::get(id, code.clone()).is_none(), Error::<T>::CodeAlreadyRegisteredInSet);
+            <CodeSets<T>>::insert(id, code.clone(), FullDoc { id, doc: code});
+            Self::deposit_event(RawEvent::NewEncodedObject(id));
+            Ok(())
+        }
+        #[weight = 0]
+        fn new_doc(
+            origin,
+            cid: T::Cid,
+        ) -> DispatchResult {
+            let _ = ensure_signed(origin)?;
+            let id = Self::generate_doc_uid();
+            <Docs<T>>::insert(id, FullDoc { id, doc: cid.clone()});
+            Self::deposit_event(RawEvent::NewDoc(id, cid));
+            Ok(())
+        }
+    }
+}
+
+impl<T: Trait> Module<T> {
+    fn code_id_dne(id: T::CodeId) -> bool {
+        <CodeSets<T>>::iter_prefix(id)
+            .map(|d| d)
+            .collect::<Vec<(EncodedObj, FullDoc<_, _>)>>()
+            .is_empty()
+    }
+    fn generate_code_uid() -> T::CodeId {
+        let mut id_counter = <CodeIdCounter<T>>::get() + 1u32.into();
+        while !Self::code_id_dne(id_counter) {
+            id_counter += 1u32.into();
+        }
+        <CodeIdCounter<T>>::put(id_counter);
+        id_counter
+    }
+    fn generate_doc_uid() -> T::DocId {
+        let mut id_counter = <DocIdCounter<T>>::get() + 1u32.into();
+        while <Docs<T>>::get(id_counter).is_some() {
+            id_counter += 1u32.into();
+        }
+        <DocIdCounter<T>>::put(id_counter);
+        id_counter
+    }
+}

--- a/pallets/doc/src/tests.rs
+++ b/pallets/doc/src/tests.rs
@@ -1,0 +1,160 @@
+use super::*;
+use frame_support::{
+    assert_noop,
+    assert_ok,
+    impl_outer_event,
+    impl_outer_origin,
+    parameter_types,
+    weights::Weight,
+};
+use rand::{
+    rngs::OsRng,
+    RngCore,
+};
+use sp_core::H256;
+use sp_runtime::{
+    testing::Header,
+    traits::IdentityLookup,
+    Perbill,
+};
+
+// type aliases
+pub type AccountId = u64;
+pub type BlockNumber = u64;
+
+impl_outer_origin! {
+    pub enum Origin for Test where system = frame_system {}
+}
+
+mod doc {
+    pub use super::super::*;
+}
+
+impl_outer_event! {
+    pub enum TestEvent for Test {
+        frame_system<T>,
+        doc<T>,
+    }
+}
+
+#[derive(Clone, Eq, PartialEq)]
+pub struct Test;
+parameter_types! {
+    pub const BlockHashCount: u64 = 250;
+    pub const MaximumBlockWeight: Weight = 1024;
+    pub const MaximumBlockLength: u32 = 2 * 1024;
+    pub const AvailableBlockRatio: Perbill = Perbill::one();
+}
+impl frame_system::Trait for Test {
+    type Origin = Origin;
+    type Index = u64;
+    type BlockNumber = BlockNumber;
+    type Call = ();
+    type Hash = H256;
+    type Hashing = ::sp_runtime::traits::BlakeTwo256;
+    type AccountId = AccountId;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = TestEvent;
+    type BlockHashCount = BlockHashCount;
+    type MaximumBlockWeight = MaximumBlockWeight;
+    type MaximumExtrinsicWeight = MaximumBlockWeight;
+    type DbWeight = ();
+    type BlockExecutionWeight = ();
+    type ExtrinsicBaseWeight = ();
+    type AvailableBlockRatio = AvailableBlockRatio;
+    type MaximumBlockLength = MaximumBlockLength;
+    type Version = ();
+    type ModuleToIndex = ();
+    type AccountData = ();
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type BaseCallFilter = ();
+    type SystemWeightInfo = ();
+}
+impl Trait for Test {
+    type Event = TestEvent;
+    type CodeId = u64;
+    type DocId = u64;
+    type Cid = u64;
+}
+pub type System = frame_system::Module<Test>;
+pub type Doc = Module<Test>;
+
+fn random(output_len: usize) -> Vec<u8> {
+    let mut buf = vec![0u8; output_len];
+    OsRng.fill_bytes(&mut buf);
+    buf
+}
+
+fn get_last_event() -> RawEvent<u64, u64, u64> {
+    System::events()
+        .into_iter()
+        .map(|r| r.event)
+        .filter_map(|e| {
+            if let TestEvent::doc(inner) = e {
+                Some(inner)
+            } else {
+                None
+            }
+        })
+        .last()
+        .unwrap()
+}
+
+fn new_test_ext() -> sp_io::TestExternalities {
+    let t = frame_system::GenesisConfig::default()
+        .build_storage::<Test>()
+        .unwrap();
+    let mut ext: sp_io::TestExternalities = t.into();
+    ext.execute_with(|| System::set_block_number(1));
+    ext
+}
+
+#[test]
+fn genesis_config_works() {
+    new_test_ext().execute_with(|| {
+        assert!(System::events().is_empty());
+    });
+}
+
+#[test]
+fn new_code_set_works() {
+    new_test_ext().execute_with(|| {
+        let new_code_set = vec![random(10), random(11)];
+        let empty_code_set = vec![];
+        assert_noop!(
+            Doc::new_code_set(Origin::signed(1), empty_code_set,),
+            Error::<Test>::MustIncludeCodeToCreateNewCodeSet
+        );
+        assert_ok!(Doc::new_code_set(Origin::signed(1), new_code_set,));
+        assert_eq!(get_last_event(), RawEvent::NewCodeSet(1));
+    });
+}
+
+#[test]
+fn new_encoded_object_works() {
+    new_test_ext().execute_with(|| {
+        let first_code = random(10);
+        let new_code_set = vec![first_code.clone(), random(11)];
+        assert_noop!(
+            Doc::new_encoded_object(Origin::signed(1), 1, random(12)),
+            Error::<Test>::CodeIdNotRegistered
+        );
+        assert_ok!(Doc::new_code_set(Origin::signed(1), new_code_set,));
+        assert_eq!(get_last_event(), RawEvent::NewCodeSet(1));
+        assert_noop!(
+            Doc::new_encoded_object(Origin::signed(1), 1, first_code),
+            Error::<Test>::CodeAlreadyRegisteredInSet
+        );
+        assert_ok!(Doc::new_encoded_object(Origin::signed(1), 1, random(12)));
+    });
+}
+
+#[test]
+fn new_doc_works() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(Doc::new_doc(Origin::signed(1), 10));
+        assert_eq!(get_last_event(), RawEvent::NewDoc(1, 10));
+    });
+}

--- a/utils/src/doc.rs
+++ b/utils/src/doc.rs
@@ -1,0 +1,12 @@
+use codec::{
+    Decode,
+    Encode,
+};
+use sp_runtime::RuntimeDebug;
+use sp_std::prelude::*;
+
+#[derive(new, PartialEq, Eq, Default, Clone, Encode, Decode, RuntimeDebug)]
+pub struct FullDoc<Id, Doc> {
+    pub id: Id,
+    pub doc: Doc,
+}

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -11,6 +11,7 @@ extern crate derive_new;
 pub mod bank;
 pub mod bounty;
 pub mod court;
+pub mod doc;
 pub mod drip;
 pub mod grant;
 pub mod kickback;


### PR DESCRIPTION
a storage utility pallet designed for inheritance by other modules and not for direct use

## motivation

1. Generalize the global hashset in the `bounty` pallet; It encodes the issues metadata and stores the encoding on-chain in a hashset. This prevents future duplicates. 

The idea behind the `CodeSets` map in this module is to allow inheriting modules to create code sets. Every code set has a `CodeId` which should be stored in the inheriting modules storage to append to any calls to add new items to the code set or check item membership.

In the future, I'd like to add requirements for each `CodeSet` like length. If I can bound the length, then I can emit events with the code as well. 

One day, I'd like an inheriting module to be able to register `CodeSets` with all codes encrypted by some shared group key. A requirement for adding an element would be that the code is in a message with a valid signature.

2. Take the constitution logic out of the Org module and replace with the `Docs` map here